### PR TITLE
Lil' Documentation change

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,6 +60,8 @@ metalsmith.use(drafts( {
 }));
 ```
 
+> Note: if you're templates don't have `draft: true` your site might disapear when on your first compile! 
+
 ## License
 
   MIT


### PR DESCRIPTION
My site disappeared until I figured out that my templates were missing the `draft` identifier. Seems like it could be a common trap.